### PR TITLE
Merge table-relation resolution code into develop

### DIFF
--- a/palladio-webcomponent-base.js
+++ b/palladio-webcomponent-base.js
@@ -155,21 +155,25 @@ class PalladioWebcomponentBase extends HTMLElement {
       fileId: link.lookup.file.uniqueId,
     }));
     try {
-      return data.files[0].data.map((row) => {
-        links.forEach(({ sourceKey, targetKey, fileId }) => {
-          const linkedFile = data.files[fileId];
-          const linkedRow = linkedFile.data.find(
-            (_linkedRow) => _linkedRow[targetKey] === row[sourceKey],
-          );
-          if (linkedRow) {
-            Object.entries(linkedRow).forEach(([key, value]) => {
-              // eslint-disable-next-line no-param-reassign
-              row[`${sourceKey}__${key}`] = value;
-            });
-          }
+      return data.files
+        .find(({ uniqueId }) => uniqueId === 0)
+        .data.map((row) => {
+          links.forEach(({ sourceKey, targetKey, fileId }) => {
+            const linkedFile = data.files.find(
+              ({ uniqueId }) => uniqueId === fileId,
+            );
+            const linkedRow = linkedFile.data.find(
+              (_linkedRow) => _linkedRow[targetKey] === row[sourceKey],
+            );
+            if (linkedRow) {
+              Object.entries(linkedRow).forEach(([key, value]) => {
+                // eslint-disable-next-line no-param-reassign
+                row[`${sourceKey}__${key}`] = value;
+              });
+            }
+          });
+          return row;
         });
-        return row;
-      });
     } catch (e) {
       return false;
     }

--- a/palladio-webcomponent-base.js
+++ b/palladio-webcomponent-base.js
@@ -156,23 +156,17 @@ class PalladioWebcomponentBase extends HTMLElement {
     }));
     try {
       return data.files[0].data.map((row) => {
-        // For each link (i.e. foreign key relation), define a getter on the row object
-        //  to fetch the value if/when it's needed (effectively a lazy denormalization)
         links.forEach(({ sourceKey, targetKey, fileId }) => {
           const linkedFile = data.files[fileId];
-          linkedFile.fields.forEach(({ key: linkedKey }) => {
-            if (Object.prototype.hasOwnProperty.call(row, linkedKey)) return;
-            Object.defineProperty(row, linkedKey, {
-              get() {
-                const linkedRow = linkedFile.data.find(
-                  (_linkedRow) => _linkedRow[targetKey] === row[sourceKey],
-                );
-
-                if (!linkedRow) return undefined;
-                return linkedRow[linkedKey];
-              },
+          const linkedRow = linkedFile.data.find(
+            (_linkedRow) => _linkedRow[targetKey] === row[sourceKey],
+          );
+          if (linkedRow) {
+            Object.entries(linkedRow).forEach(([key, value]) => {
+              // eslint-disable-next-line no-param-reassign
+              row[`${sourceKey}__${key}`] = value;
             });
-          });
+          }
         });
         return row;
       });


### PR DESCRIPTION
This update supports table-relation resolution in the map component (and also fixes up some issues with tooltips for point-to-point data layers).

There is a fundamental problem with the way that the table relations are encoded in Palladio `.json` save files.  The code in this PR is more of a workaround than a comprehensive solution to this problem, but I don't know that there are any really *good* solutions that don't involve converting the Palladio save file format in some fashion, which comes with some pretty big downsides as well as some pretty big upsides.  Unclear how to proceed.  However, this addresses the issue for a majority of cases, so, in the spirit of not letting the perfect be the enemy of the good...